### PR TITLE
Appending the -c flag by default when -C is passed

### DIFF
--- a/opm.1
+++ b/opm.1
@@ -59,11 +59,11 @@ This option forces the use of the $EDITOR for adding
 entries.
 .It Fl C Ar clipboard
 Specifies which clipboard to use.
-Shorthand for
-.Fl c 
-without additional argument.
 Defaults to
 .Pa primary .
+This option also sets the
+.It Fl c
+argument .
 .It Fl S Ar file
 Path to the signify private key.
 .It Fl P Ar file

--- a/opm.1
+++ b/opm.1
@@ -42,7 +42,9 @@ The options are as follows:
 .It Fl b
 Enable batch mode for listing the entries, avoiding the tree output.
 .It Fl c
-Copy the password to the clipboard for one time paste only.
+Use 
+.Xr xclip 1
+to copy the password to the clipboard for one time paste only.
 .It Fl d
 Turn on debug messages.
 .It Fl h
@@ -57,6 +59,9 @@ This option forces the use of the $EDITOR for adding
 entries.
 .It Fl C Ar clipboard
 Specifies which clipboard to use.
+Shorthand for
+.Fl c 
+without additional argument.
 Defaults to
 .Pa primary .
 .It Fl S Ar file
@@ -79,7 +84,7 @@ Remove the specified entry.
 Show the list of existing entries.
 .It Cm encrypt Ar group/entry
 Re-encrypt the specified path.
-If not path is specified, all entries will be re-encrypted.
+If no path is specified, all entries will be re-encrypted.
 .It Cm show | get Ar group/entry
 Show the contents of an entry after decryption.
 .It Cm verify

--- a/opm.sh
+++ b/opm.sh
@@ -245,7 +245,7 @@ trap 'trap_handler' EXIT HUP INT TERM
 
 while getopts C:S:P:bcdhkmp:s: arg; do
 	case ${arg} in
-		C) _CBOARD="${OPTARG}" ;;
+		C) _CBOARD="${OPTARG}" && _CLIP=1 ;;
 		c) _CLIP=1 ;;
 		S) _SPRIVATE_KEY="${OPTARG}" ;;
 		s) _PRIVATE_KEY="${OPTARG}" ;;


### PR DESCRIPTION
Appending the -c flag by default when -C is passed to specify a clipboard since there doesn't seem to be a use case for when you pass -C and wouldn't also want and need to include -c . Man page updates to reflect new behavior. Not sure if the verbiage is concise enough.