### PR TITLE
Bug fix for some single line entries being interpreted as multi-line entries

### DIFF
--- a/opm.sh
+++ b/opm.sh
@@ -222,10 +222,10 @@ show_entry()
 		[ -z ${_HIGHLIGHT} ] || tput smso && echo "${_e}" && \
 			tput rmso || echo "${_e}"
 	else
-		[[ ${_e} == *\n* ]] && _ML=1
+		[[ ${_e} == *"\n"* ]] && _ML=1
 		opm_debug "Copying to clipboard=${_CBOARD}, multiline=${_ML}"
 		[ ${_ML} -gt 0 ] && _e=$(echo "${_e}" | sed -n '2p')
-		printf '%s' "${_e}" | xclip -selection ${_CBOARD} -loop 1
+		printf "%s" "${_e}" | xclip -selection ${_CBOARD} -loop 1
 	fi
 }
 
@@ -245,7 +245,7 @@ trap 'trap_handler' EXIT HUP INT TERM
 
 while getopts C:S:P:bcdhkmp:s: arg; do
 	case ${arg} in
-		C) _CBOARD="${OPTARG}" ;;
+		C) _CBOARD="${OPTARG}" && _CLIP=1 ;;
 		c) _CLIP=1 ;;
 		S) _SPRIVATE_KEY="${OPTARG}" ;;
 		s) _PRIVATE_KEY="${OPTARG}" ;;

--- a/opm.sh
+++ b/opm.sh
@@ -245,7 +245,7 @@ trap 'trap_handler' EXIT HUP INT TERM
 
 while getopts C:S:P:bcdhkmp:s: arg; do
 	case ${arg} in
-		C) _CBOARD="${OPTARG}" && _CLIP=1 ;;
+		C) _CBOARD="${OPTARG}" ;;
 		c) _CLIP=1 ;;
 		S) _SPRIVATE_KEY="${OPTARG}" ;;
 		s) _PRIVATE_KEY="${OPTARG}" ;;


### PR DESCRIPTION
If you save a password that contains the string n for example pn and use the -c or -C flags to send it to a clipboard it is misinterpreted as a multi-line entry and the wrong line is saved (the empty second one).

#6 